### PR TITLE
Fixes #47: catch exception if pos['description'] is None

### DIFF
--- a/scrape_linkedin/utils.py
+++ b/scrape_linkedin/utils.py
@@ -138,8 +138,11 @@ def get_job_info(job):
         for pos in positions:
             pos['company'] = company
             pos['li_company_url'] = li_company_url
-            pos['description'] = pos['description'].replace(
-                'See less\n', '').replace('... See more', '').strip()
+            try:
+                pos['description'] = pos['description'].replace(
+                    'See less\n', '').replace('... See more', '').strip()
+            except:
+                pass
 
         return positions
 


### PR DESCRIPTION
Use try except instead of pos.get('description', '') to keep pos['description'] at None instead of the empty string ''.

This choice was made in order to be consistent with the behavior l.157-161