### PR TITLE
Load https version of Linkedin

### DIFF
--- a/scrape_linkedin/ConnectionScraper.py
+++ b/scrape_linkedin/ConnectionScraper.py
@@ -33,7 +33,7 @@ class ConnectionScraper(Scraper):
             ValueError: If link doesn't match a typical profile url
         """
         if user:
-            url = 'http://www.linkedin.com/in/' + user
+            url = 'https://www.linkedin.com/in/' + user
         if 'com/in/' not in url:
             raise ValueError("Url must look like ...linkedin.com/in/NAME")
         self.current_profile = url.split(r'com/in/')[1]

--- a/scrape_linkedin/ProfileScraper.py
+++ b/scrape_linkedin/ProfileScraper.py
@@ -37,7 +37,7 @@ class ProfileScraper(Scraper):
             ValueError: If link doesn't match a typical profile url
         """
         if user:
-            url = 'http://www.linkedin.com/in/' + user
+            url = 'https://www.linkedin.com/in/' + user
         if 'com/in/' not in url and 'sales/gmail/profile/proxy/' not in url:
             raise ValueError(
                 "Url must look like... .com/in/NAME or... '.com/sales/gmail/profile/proxy/EMAIL")

--- a/scrape_linkedin/Scraper.py
+++ b/scrape_linkedin/Scraper.py
@@ -40,7 +40,7 @@ class Scraper(object):
         self.scroll_pause = scroll_pause
         self.scroll_increment = scroll_increment
         self.timeout = timeout
-        self.driver.get('http://www.linkedin.com')
+        self.driver.get('https://www.linkedin.com')
         self.driver.set_window_size(1920, 1080)
 
         if 'LI_EMAIL' in environ and 'LI_PASS' in environ:

--- a/scrape_linkedin/cli.py
+++ b/scrape_linkedin/cli.py
@@ -40,9 +40,9 @@ def scrape(url, user, company, attribute, input_file, headless, output_file, dri
     if headless:
         driver_options = HEADLESS_OPTIONS
     if company:
-        url = 'http://www.linkedin.com/company/' + company
+        url = 'https://www.linkedin.com/company/' + company
     if user:
-        url = 'http://www.linkedin.com/in/' + user
+        url = 'https://www.linkedin.com/in/' + user
     if (url and input_file) or (not url and not input_file):
         raise ClickException(
             'Must pass either a url or file path, but not both.')


### PR DESCRIPTION
Currently the driver loads the insecure http version of LinkedIn (which is eventually redirected to https) but in some cases it might be susceptible to MITM attacks or otherwise not allowed in a particular network ecosystem. In my case, our network interface automatically blocks all non https connections. I don't see a reason why https isn't loaded in the first place rather than waiting for a redirect from LinkedIn to https.